### PR TITLE
Timestamp Index for Station Observer Requests

### DIFF
--- a/src/ticktrack/__main__.py
+++ b/src/ticktrack/__main__.py
@@ -4,6 +4,8 @@ import os
 import time
 import yaml
 
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
 from sqlobject import connectionForURI, sqlhub
 from typing import List
 
@@ -47,11 +49,22 @@ def observe(database, config):
     # start monitor thread for each station ID
     station_ids: List[str] = [s.strip() for s in config['stations']]
 
+    # create next departure index
+    station_dep_index = defaultdict(lambda: None)
+
     while True:
 
         logging.info('Performing observer requests ...')
 
         for station_id in station_ids:
+
+            # check if station preview time is reached
+            next_departure_time = station_dep_index[station_id]
+            if next_departure_time is not None and next_departure_time >= datetime.now(timezone.utc) + timedelta(minutes=5):
+                logging.debug(f"Skipping station {station_id}, preview time window not reached")
+                continue
+            
+            # run worker for this station
             worker: MonitorWorker = MonitorWorker(
                 database,
                 config['app']['endpoint'], 
@@ -63,6 +76,9 @@ def observe(database, config):
                 worker.start(station_id, [l.strip() for l in config['lines']])
             else:
                 worker.start(station_id, None)
+
+            # store next departure index
+            station_dep_index[station_id] = worker.next_departure_timestamp
 
         time.sleep(60)
     

--- a/src/ticktrack/request.py
+++ b/src/ticktrack/request.py
@@ -51,7 +51,7 @@ class StopEventRequest(ServiceRequest):
         self.Trias.ServiceRequest.RequestPayload.StopEventRequest.DepArrTime = dep_arr_time
 
         self.Trias.ServiceRequest.RequestPayload.StopEventRequest.Params = Element('Params')
-        self.Trias.ServiceRequest.RequestPayload.StopEventRequest.Params.NumberOfResults = str(40)
+        self.Trias.ServiceRequest.RequestPayload.StopEventRequest.Params.NumberOfResults = str(20)
         self.Trias.ServiceRequest.RequestPayload.StopEventRequest.Params.StopEventType = 'departure'
         self.Trias.ServiceRequest.RequestPayload.StopEventRequest.Params.IncludeRealtimeData = str(True).lower()
         self.Trias.ServiceRequest.RequestPayload.StopEventRequest.Params.IncludePreviousCalls = str(True).lower()


### PR DESCRIPTION
An index has been implemented to keep track of the next departures for each station. An observer is performed only when the next departure time is in a preview time window of 5 minutes. This saves a lot of requests and data transfer between the client and the VDV431 API.